### PR TITLE
fix: add method to count employee vacation days and update TimeBalanc…

### DIFF
--- a/ChronoLog.Applications/Services/EmployeeContextService.cs
+++ b/ChronoLog.Applications/Services/EmployeeContextService.cs
@@ -160,6 +160,25 @@ public class EmployeeContextService : IEmployeeContextService
 
         return absenceDays;
     }
+    
+    public async Task<int> GetEmployeeVacationDaysCountAsync(Guid employeeId, int year)
+    {
+        int vacationDays;
+        await _initializationLock.WaitAsync();
+        try
+        {
+            vacationDays = await _sqlDbContext.Workdays
+                .Where(w => w.EmployeeId == employeeId)
+                .Where(w => w.Date.Year == year)
+                .Where(w => w.Type == WorkdayType.Urlaub)
+                .CountAsync();
+        }
+        finally
+        {
+            _initializationLock.Release();
+        }
+        return vacationDays;
+    }
 
     public async Task<bool> UpdateEmployeeAsync(EmployeeModel employee)
     {

--- a/ChronoLog.ChronoLogService/Components/Pages/TimeBalance.razor
+++ b/ChronoLog.ChronoLogService/Components/Pages/TimeBalance.razor
@@ -46,7 +46,7 @@
                 <RadzenStack Gap="0.5rem">
                     <RadzenText TextStyle="TextStyle.H6">Vacation @_selectedYear</RadzenText>
                     <RadzenText TextStyle="TextStyle.H3" Style="color: rgba(103, 58, 183, 1)">
-                        @(_absenceDays.Count(a => a.AbsenceTypes.Split(", ").Contains(nameof(WorkdayType.Urlaub)))) / @_vacationDaysPerYear
+                        @_vacationDaysTaken / @_vacationDaysPerYear
                     </RadzenText>
                     <RadzenText TextStyle="TextStyle.Body2">Remaining: @RemainingVacationDays Days</RadzenText>
                 </RadzenStack>
@@ -106,6 +106,7 @@
     private int RemainingVacationDays => _vacationDaysPerYear - _absenceDays.Count(a => a.AbsenceTypes.Split(", ").Contains(nameof(WorkdayType.Urlaub)));
     private double _totalOvertime;
     private int _officeDays;
+    private int _vacationDaysTaken;
 
     protected override async Task OnInitializedAsync()
     {
@@ -118,8 +119,10 @@
 
     private async Task LoadAbsenceDaysAsync()
     {
-        if (_currentEmployee != null)
-            _absenceDays = await EmployeeContextService.GetEmployeeAbsenceDaysAsync(_currentEmployee.EmployeeId, _selectedYear);
+        if (_currentEmployee is null)
+            return;
+        _absenceDays = await EmployeeContextService.GetEmployeeAbsenceDaysAsync(_currentEmployee.EmployeeId, _selectedYear);
+        _vacationDaysTaken = await EmployeeContextService.GetEmployeeVacationDaysCountAsync(_currentEmployee.EmployeeId, _selectedYear);
     }
     
     private async Task LoadOfficeDaysAsync()

--- a/ChronoLog.Core/Interfaces/IEmployeeContextService.cs
+++ b/ChronoLog.Core/Interfaces/IEmployeeContextService.cs
@@ -7,6 +7,7 @@ public interface IEmployeeContextService
 {
     Task<EmployeeModel> GetOrCreateCurrentEmployeeAsync();
     Task<List<AbsenceEntryModel>> GetEmployeeAbsenceDaysAsync(Guid employeeId, int year);
+    Task<int> GetEmployeeVacationDaysCountAsync(Guid employeeId, int year);
     Task<List<EmployeeModel>> GetAllEmployeesAsync();
     Task<bool> UpdateEmployeeAsync(EmployeeModel employee);
 }


### PR DESCRIPTION
This pull request introduces a new method to accurately calculate and display the number of vacation days taken by an employee in a given year, and updates the UI to use this new calculation. The changes ensure that vacation day counts are retrieved directly from the database rather than inferred from absence types, improving accuracy and maintainability.

**Backend enhancements:**

* Added `GetEmployeeVacationDaysCountAsync` method to `IEmployeeContextService` interface and its implementation in `EmployeeContextService`, which counts vacation days (`WorkdayType.Urlaub`) for a specific employee and year directly from the database. [[1]](diffhunk://#diff-91b7f878e7ac2a263d4a3154fe495a5710c36f19c406aa7d5e5fabf701f0cb2cR10) [[2]](diffhunk://#diff-e89ce33c57e73368528ef2c6d740b3434b402b2b5798644127dd0924fbebfc25R164-R182)

**Frontend/UI updates:**

* Updated the vacation days display in `TimeBalance.razor` to use the new `_vacationDaysTaken` property, which is set by calling the new backend method, instead of counting from the absence days list. [[1]](diffhunk://#diff-241bb2b405e593c290c610504f8f7f775a268add7333ef40a03f4de3eac02760L49-R49) [[2]](diffhunk://#diff-241bb2b405e593c290c610504f8f7f775a268add7333ef40a03f4de3eac02760R109) [[3]](diffhunk://#diff-241bb2b405e593c290c610504f8f7f775a268add7333ef40a03f4de3eac02760L121-R125)
* Improved null checking in `LoadAbsenceDaysAsync` to prevent errors when the current employee is not set.…e component