### PR TITLE
fix: update Dockerfile to install curl for improved functionality

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 ﻿FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443


### PR DESCRIPTION
This pull request makes a small change to the `Dockerfile` by installing `curl` in the base image. This will allow the container to make HTTP requests, which can be useful for debugging or interacting with external services.