### PR TITLE
Feat/refine timeentry management

### DIFF
--- a/ChronoLog.ChronoLogService/Components/Pages/Overview/EditWorkdayDialog.razor
+++ b/ChronoLog.ChronoLogService/Components/Pages/Overview/EditWorkdayDialog.razor
@@ -256,6 +256,15 @@ else
                                     </EditTemplate>
                                 </RadzenDataGridColumn>
                             </Columns>
+                            
+                            <FooterTemplate>
+                                <div class="rz-d-flex rz-justify-content-end rz-p-2">
+                                    <strong>Total Project Time: </strong>&nbsp;
+                                    <span>
+                                        @(CalculateTotalProjectTime()?.ToString(@"hh\:mm\:ss") ?? "N/A")
+                                    </span>
+                                </div>
+                            </FooterTemplate>
                         </RadzenDataGrid>
                     </RadzenCard>
                 </RadzenCardGroup>
@@ -482,6 +491,20 @@ else
         }
 
         return totalWorktime;
+    }
+
+    private TimeSpan? CalculateTotalProjectTime()
+    {
+        IEnumerable<TimeEntryModel> timeEntrySource;
+        
+        if (_timeEntries.Any())
+            timeEntrySource = _timeEntries;
+        else if (Workday is not null)
+            timeEntrySource = Workday.TimeEntries;
+        else
+            return null;
+
+        return timeEntrySource.Aggregate(TimeSpan.Zero, (current, timeEntry) => current + timeEntry.Duration);
     }
 
     void OnSubmit(WorkdaySummaryViewModel model)

--- a/ChronoLog.ChronoLogService/Components/Pages/Overview/EditWorkdayDialog.razor
+++ b/ChronoLog.ChronoLogService/Components/Pages/Overview/EditWorkdayDialog.razor
@@ -185,8 +185,11 @@ else
                                                     <RadzenDropDown Data="@_projects"
                                                                     TextProperty="Name"
                                                                     ValueProperty="ProjectId"
+                                                                    Name="ProjectSelect"
                                                                     @bind-Value="timeEntry.ProjectId"
-                                                                    Name="ProjectSelect"/>
+                                                                    FilterOperator="StringFilterOperator.Contains"
+                                                                    FilterCaseSensitivity="FilterCaseSensitivity.CaseInsensitive"
+                                                                    AllowFiltering="true"/>
                                                     <RadzenRequiredValidator Component="ProjectSelect"
                                                                              Text="Project is mandatory."/>
                                                 </ChildContent>
@@ -256,7 +259,7 @@ else
                                     </EditTemplate>
                                 </RadzenDataGridColumn>
                             </Columns>
-                            
+
                             <FooterTemplate>
                                 <div class="rz-d-flex rz-justify-content-end rz-p-2">
                                     <strong>Total Project Time: </strong>&nbsp;
@@ -496,7 +499,7 @@ else
     private TimeSpan? CalculateTotalProjectTime()
     {
         IEnumerable<TimeEntryModel> timeEntrySource;
-        
+
         if (_timeEntries.Any())
             timeEntrySource = _timeEntries;
         else if (Workday is not null)
@@ -511,4 +514,5 @@ else
     {
         DialogService.Close(model);
     }
+
 }

--- a/ChronoLog.ChronoLogService/Components/Pages/Projects/Projects.razor
+++ b/ChronoLog.ChronoLogService/Components/Pages/Projects/Projects.razor
@@ -22,7 +22,8 @@ else
     <div style="display: flex; flex-direction: column; height: 100%; gap: 10px;">
         <RadzenCard>
             <div style="display: flex; justify-content: space-between; align-items: center;">
-                <RadzenButton Text="Create Project" ButtonStyle="ButtonStyle.Success" Variant="Variant.Outlined" Click="OpenCreateProjectDialog"/>
+                <RadzenButton Text="Create Project" ButtonStyle="ButtonStyle.Success" Variant="Variant.Outlined"
+                              Click="OpenCreateProjectDialog"/>
             </div>
         </RadzenCard>
         <RadzenCard>
@@ -57,7 +58,9 @@ else
                                 LogicalFilterOperator="LogicalFilterOperator.And"
                                 FilterPopupRenderMode="PopupRenderMode.OnDemand">
                     <Columns>
-                        <RadzenDataGridColumn Property="@nameof(ProjectModel.IsDefault)" Title="Default" Filterable="false" Sortable="false" Resizable="false" Width="30px" TextAlign="TextAlign.Center">
+                        <RadzenDataGridColumn Property="@nameof(ProjectModel.IsDefault)" Title="Default"
+                                              Filterable="false" Sortable="false" Resizable="false" Width="30px"
+                                              TextAlign="TextAlign.Center">
                             <Template Context="item">
                                 @if (item.IsDefault)
                                 {
@@ -75,7 +78,13 @@ else
                                 @item.ResponseObject
                             </Template>
                         </RadzenDataGridColumn>
-                        <RadzenDataGridColumn Filterable="false" Sortable="false" Resizable="false" Width="40px" TextAlign="TextAlign.Center">
+                        <RadzenDataGridColumn Property="@nameof(ProjectModel.DefaultResponseText)" Title="Default Response Text">
+                            <Template Context="item">
+                                @item.DefaultResponseText
+                            </Template>
+                        </RadzenDataGridColumn>
+                        <RadzenDataGridColumn Filterable="false" Sortable="false" Resizable="false" Width="40px"
+                                              TextAlign="TextAlign.Center">
                             <Template Context="item">
                                 <RadzenButton Icon="edit"
                                               ButtonStyle="ButtonStyle.Light"
@@ -99,19 +108,19 @@ else
 
 @code {
     private bool _isAuthorized;
-    
+
     private List<ProjectModel> _projects = [];
-    
+
     private RadzenDataGrid<ProjectModel>? _grid;
     private IList<ProjectModel>? _selectedProject;
     private string _searchText = "";
-    
+
     private List<ProjectModel> FilteredProjects => string.IsNullOrWhiteSpace(_searchText)
         ? _projects
-        : _projects.Where(p => 
-            p.Name.Contains(_searchText, StringComparison.OrdinalIgnoreCase) || 
+        : _projects.Where(p =>
+            p.Name.Contains(_searchText, StringComparison.OrdinalIgnoreCase) ||
             p.ProjectId.ToString().Contains(_searchText, StringComparison.OrdinalIgnoreCase)
-            ).ToList();
+        ).ToList();
 
     protected override async Task OnInitializedAsync()
     {
@@ -123,7 +132,7 @@ else
             NavigationManager.NavigateTo("/");
             return;
         }
-        
+
         await LoadData();
         if (_selectedProject is null || !_selectedProject.Any())
             _selectedProject = _projects.Take(1).ToList();
@@ -140,35 +149,35 @@ else
         _searchText = string.Empty;
         if (_grid is null)
             return;
-        
+
         foreach (var column in _grid.ColumnsCollection)
             await column.SetFilterValueAsync(null);
-        
+
         await _grid.Reload();
     }
-    
+
     private void OnSearchTextChanged(object? value)
     {
         _searchText = value?.ToString() ?? string.Empty;
     }
-    
+
     private async Task OpenCreateProjectDialog()
     {
         await DialogService.OpenAsync<CreateProjectDialog>(
             "Create Project",
             new Dictionary<string, object>(),
             new DialogOptions
-                {
-                    Width = "600px", 
-                    Height = "500px",
-                    CloseDialogOnEsc = true,
-                    CloseDialogOnOverlayClick = true
-                }
+            {
+                Width = "600px",
+                Height = "500px",
+                CloseDialogOnEsc = true,
+                CloseDialogOnOverlayClick = true
+            }
         );
-        
+
         await LoadData();
     }
-    
+
     private async Task OpenEditProjectDialog(ProjectModel project)
     {
         await DialogService.OpenAsync<EditProjectDialog>(
@@ -178,17 +187,17 @@ else
                 { "Project", project }
             },
             new DialogOptions
-                {
-                    Width = "600px", 
-                    Height = "500px",
-                    CloseDialogOnEsc = true,
-                    CloseDialogOnOverlayClick = true
-                }
+            {
+                Width = "600px",
+                Height = "500px",
+                CloseDialogOnEsc = true,
+                CloseDialogOnOverlayClick = true
+            }
         );
-        
+
         await LoadData();
     }
-    
+
     private async Task ConfirmDelete(ProjectModel project)
     {
         var confirmed = await DialogService.Confirm($"Delete \"{project.Name}\" permanently?", "Delete project",
@@ -221,4 +230,5 @@ else
             Console.Error.WriteLine(ex);
         }
     }
+
 }


### PR DESCRIPTION
This pull request introduces several improvements to the user interface and functionality of the `EditWorkdayDialog` and `Projects` pages. The main enhancements include better filtering options for project selection, displaying the total project time in the workday editor, and adding a new column to the projects data grid.

**EditWorkdayDialog improvements:**

* Enhanced the project selection dropdown (`RadzenDropDown`) to support filtering by project name, making it easier for users to find and select projects. The filtering is now case-insensitive and allows partial matches.
* Added a footer to the `RadzenDataGrid` that displays the total project time, calculated by summing up the durations of all time entries for the day. This provides users with immediate feedback on their logged project time. [[1]](diffhunk://#diff-84abd7ac5ca274d8c620bfa52e28841197f86098cb911916e40cec7a37c374d7R262-R270) [[2]](diffhunk://#diff-84abd7ac5ca274d8c620bfa52e28841197f86098cb911916e40cec7a37c374d7R499-R517)

**Projects page enhancements:**

* Introduced a new column, `Default Response Text`, to the projects data grid, displaying each project's default response text for better visibility and management.
* Minor formatting improvements to the markup for better readability and maintainability. [[1]](diffhunk://#diff-c37da3e8dcf6081fa93ff3ee1a88443d304ba0e949d8d194af41b2abcf396387L25-R26) [[2]](diffhunk://#diff-c37da3e8dcf6081fa93ff3ee1a88443d304ba0e949d8d194af41b2abcf396387L60-R63) [[3]](diffhunk://#diff-c37da3e8dcf6081fa93ff3ee1a88443d304ba0e949d8d194af41b2abcf396387R233)