### PR TITLE
feat: update nuget packages

### DIFF
--- a/ChronoLog.Applications/ChronoLog.Applications.csproj
+++ b/ChronoLog.Applications/ChronoLog.Applications.csproj
@@ -7,9 +7,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="10.0.0" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0" />
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
+      <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="10.0.8" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.8" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
     </ItemGroup>
     
     <ItemGroup>

--- a/ChronoLog.ChronoLogService/ChronoLog.ChronoLogService.csproj
+++ b/ChronoLog.ChronoLogService/ChronoLog.ChronoLogService.csproj
@@ -10,25 +10,25 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.AspNetCore.HeaderPropagation" Version="10.0.0" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.0" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0">
+      <PackageReference Include="Microsoft.AspNetCore.HeaderPropagation" Version="10.0.8" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.0" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.0" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.0">
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.8" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.8">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.0" />
-      <PackageReference Include="Microsoft.Identity.Web" Version="4.3.0" />
-      <PackageReference Include="Microsoft.Identity.Web.UI" Version="4.2.0" />
-      <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="10.0.0-rc.1.25458.5" />
-      <PackageReference Include="PublicHoliday" Version="3.9.0" />
-      <PackageReference Include="Radzen.Blazor" Version="8.3.9" />
-      <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.0" />
+      <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.8" />
+      <PackageReference Include="Microsoft.Identity.Web" Version="4.10.0" />
+      <PackageReference Include="Microsoft.Identity.Web.UI" Version="4.10.0" />
+      <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="10.0.2" />
+      <PackageReference Include="PublicHoliday" Version="3.13.0" />
+      <PackageReference Include="Radzen.Blazor" Version="10.4.6" />
+      <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
     </ItemGroup>
     
     <ItemGroup>

--- a/ChronoLog.SqlDatabase/ChronoLog.SqlDatabase.csproj
+++ b/ChronoLog.SqlDatabase/ChronoLog.SqlDatabase.csproj
@@ -7,10 +7,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.0" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0" />
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
-      <PackageReference Include="MySql.EntityFrameworkCore" Version="10.0.0-rc" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.8" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
+      <PackageReference Include="MySql.EntityFrameworkCore" Version="10.0.7" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This pull request updates several NuGet package dependencies across multiple projects to ensure compatibility, security, and access to the latest features and bug fixes. The updates primarily focus on bringing Microsoft and third-party libraries to their most recent stable versions.

Dependency updates:

**Microsoft package updates:**
* Updated various Microsoft packages (such as `Microsoft.AspNetCore.Components.Authorization`, `Microsoft.Extensions.Configuration.Abstractions`, `Microsoft.Extensions.DependencyInjection.Abstractions`, `Microsoft.EntityFrameworkCore`, and related EF Core packages) from version `10.0.0` to `10.0.8` in `ChronoLog.Applications`, `ChronoLog.ChronoLogService`, and `ChronoLog.SqlDatabase` projects. [[1]](diffhunk://#diff-c5466fd6916f3081df51c938cae4890b7e85436819b5980a450e2aee5ae966baL10-R12) [[2]](diffhunk://#diff-e571bfbee80639dd2a39d0b4c0a2812952d84dd3e3236e7c6b492fab19e6b901L13-R31) [[3]](diffhunk://#diff-52926967317689c07d8e466fdb87cb3100592d018561a1e94aa98cb5dc0c5615L10-R13)

**Third-party and tooling updates:**
* Updated `Microsoft.Identity.Web` and `Microsoft.Identity.Web.UI` from `4.3.0`/`4.2.0` to `4.10.0` in `ChronoLog.ChronoLogService`.
* Updated `Microsoft.VisualStudio.Web.CodeGeneration.Design` from a release candidate to `10.0.2`, and updated `Swashbuckle.AspNetCore`, `PublicHoliday`, and `Radzen.Blazor` to their latest versions in `ChronoLog.ChronoLogService`.
* Upgraded `MySql.EntityFrameworkCore` from `10.0.0-rc` to `10.0.7` in `ChronoLog.SqlDatabase`.